### PR TITLE
Make vsi tutorial to turn on/off pwm interface

### DIFF
--- a/source/getting-started/tutorials/vsi/index.md
+++ b/source/getting-started/tutorials/vsi/index.md
@@ -290,8 +290,8 @@ int cmd_ctrl(int argc, char **argv)
             return CMD_FAILURE;
         }
         if (pwm_enable() != SUCCESS) {
-			return CMD_FAILURE;
-		}
+            return CMD_FAILURE;
+        }
 
         return CMD_SUCCESS;
     }
@@ -301,8 +301,8 @@ int cmd_ctrl(int argc, char **argv)
             return CMD_FAILURE;
         }
         if (pwm_disable() != SUCCESS) {
-			return CMD_FAILURE;
-		}
+            return CMD_FAILURE;
+        }
 
         return CMD_SUCCESS;
     }

--- a/source/getting-started/tutorials/vsi/index.md
+++ b/source/getting-started/tutorials/vsi/index.md
@@ -260,6 +260,7 @@ int cmd_ctrl(int argc, char **argv);
 #include "sys/defines.h"
 #include "sys/util.h"
 #include "usr/controller/task_controller.h"
+#include "drv/pwm.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -288,6 +289,9 @@ int cmd_ctrl(int argc, char **argv)
         if (task_controller_init() != SUCCESS) {
             return CMD_FAILURE;
         }
+        if (pwm_enable() != SUCCESS) {
+			return CMD_FAILURE;
+		}
 
         return CMD_SUCCESS;
     }
@@ -296,6 +300,9 @@ int cmd_ctrl(int argc, char **argv)
         if (task_controller_deinit() != SUCCESS) {
             return CMD_FAILURE;
         }
+        if (pwm_disable() != SUCCESS) {
+			return CMD_FAILURE;
+		}
 
         return CMD_SUCCESS;
     }


### PR DESCRIPTION
Fixes #35 

Update ctrl `init` and `deinit` commands so that they turn on/off the pwm interface. 

This is done by calling `pwm_enable()` and `pwm_disable()` within the `init` and `deinit` command function. This means that if the PWM interface is already enabled (i.e. via `hw pwm on`) when someone issues a `ctrl init` command, the user will receive a failure notification. Likewise if someone issues `ctrl deinit`, but the PWM interface has been previously disabled (`hw pwm off`) the user will receive a failure response. This may be confusing... but I think it is an acceptable implementation and consistent with how `hw pwm on` and `hw pwm off` are implemented.