### PR TITLE
Add hint on choice of repo folder

### DIFF
--- a/source/firmware/xilinx-tools/building-and-running-firmware.md
+++ b/source/firmware/xilinx-tools/building-and-running-firmware.md
@@ -52,6 +52,12 @@ my-AMDC-workspace/              <= master repo
 
 NOTE: In the rest of this document, `$REPO_DIR` represents the file system path of the `AMDC-Firmware` repository, _not your master repo_.
 
+```{attention}
+If you plan to work on your private user repositories on multiple computers, it is recommended that you clone it to the same directory on each computer. Take this into consideration when first establishing your private repo (i.e., don't clone it to the `D` drive if not all computers have a second hard drive).
+
+This is due to certain Xilinx SDK settings using absolute (instead of relative) file system paths.
+```
+
 #### Common `git submodule` commands
 
 Your repo now contains `AMDC-Firmware` as a _git submodule_. Read about submodules [here](https://git-scm.com/book/en/v2/Git-Tools-Submodules) or [here](https://www.vogella.com/tutorials/GitSubmodules/article.html). The most common command you will use is the **update** command, which updates your submodule from the remote source. Execute this command from your master repo: `git submodule update`. If you have not initialized your submodules, append `--init` to the previous command.


### PR DESCRIPTION
This PR adds a user alert regarding the choice of folder for establishing a private AMDC repository. Some of the configuration settings that we establish in SDK cause `.project` and `.cproject` to have absolute file system paths. This can cause problems when editting a private user repo across multiple computers.

![image](https://user-images.githubusercontent.com/7421348/170754463-dc3de7cf-d5bb-4787-ac29-93bd758980c7.png)

![image](https://user-images.githubusercontent.com/7421348/170754754-78e89140-c2b4-493a-9263-9ed8ca0f331c.png)
