### PR TITLE
Fix broken link to blink app

### DIFF
--- a/source/firmware/arch/index.md
+++ b/source/firmware/arch/index.md
@@ -67,7 +67,7 @@ However, each user application will most likely require its own commands in addi
 
 ## Examples
 
-To fully grasp the AMDC firmware architecture, examples are provided which concretely show the ideas presented above. See the example application: [`blink`](https://github.com/Severson-Group/AMDC-Firmware/tree/develop/sdk/bare/user/usr/blink).
+To fully grasp the AMDC firmware architecture, examples are provided which concretely show the ideas presented above. See the example application: [`blink`](https://github.com/Severson-Group/AMDC-Firmware/tree/v1.0.x/sdk/app_cpu1/user/usr/blink).
 
 ```{toctree}
 :hidden:


### PR DESCRIPTION
The [Examples section of the Firmware Architecture](https://docs.amdc.dev/firmware/arch/index.html#examples) page links to the `blink` app. This link is out of date (it corresponds to the old, single-core architecture). This PR is to fix the broken link by pointing to the `blink` app's new location in the dual core architecture.