### PR TITLE
Update firmware architecture block diagram

### DIFF
--- a/source/firmware/arch/images/block-diagram.svg
+++ b/source/firmware/arch/images/block-diagram.svg
@@ -2,25 +2,106 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="247.11436mm"
-   height="264.10059mm"
-   viewBox="0 0 247.11437 264.10059"
+   width="3.2in"
+   height="2.2in"
+   viewBox="0 0 81.280003 55.880003"
    version="1.1"
    id="svg8"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
-   sodipodi:docname="block-diagram.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   sodipodi:docname="block-diagram2.svg"
    inkscape:export-filename="C:\Users\npetersen2\Documents\GitHub\AMDC-Firmware\docs\images\arch\block-diagram.png"
    inkscape:export-xdpi="300"
-   inkscape:export-ydpi="300">
+   inkscape:export-ydpi="300"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2" />
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="marker5173"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.5"
+       markerHeight="2.89017342"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path5171" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleStart"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.5"
+       markerHeight="2.89017342"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path135" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleStart-7"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.5"
+       markerHeight="2.89017342"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path135-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker5173-1"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.5"
+       markerHeight="2.89017342"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path5171-7" />
+    </marker>
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -28,11 +109,11 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.49497475"
-     inkscape:cx="300.51025"
-     inkscape:cy="662.88694"
+     inkscape:zoom="2.8"
+     inkscape:cx="134.82143"
+     inkscape:cy="103.92857"
      inkscape:document-units="mm"
-     inkscape:current-layer="layer4"
+     inkscape:current-layer="g1042"
      showgrid="false"
      inkscape:snap-global="true"
      inkscape:snap-bbox="true"
@@ -55,7 +136,11 @@
      fit-margin-left="10"
      fit-margin-top="10"
      fit-margin-bottom="10"
-     fit-margin-right="10" />
+     fit-margin-right="10"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showguides="false" />
   <metadata
      id="metadata5">
     <rdf:RDF>
@@ -64,7 +149,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -73,717 +157,901 @@
      inkscape:groupmode="layer"
      id="layer1"
      style="display:inline"
-     transform="translate(60.880295,-36.595864)">
-    <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 20.312484,134.23285 H 161.69806"
-       id="path815"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path832"
-       d="M 20.312484,192.97072 H 161.69806"
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       sodipodi:nodetypes="cc" />
-    <rect
-       style="fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834"
-       width="25.830168"
-       height="20.053076"
-       x="26.081707"
-       y="200.88026" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="30.969494"
-       y="213.57799"
-       id="text838"><tspan
-         sodipodi:role="line"
-         id="tspan836"
-         x="30.969494"
-         y="213.57799"
-         style="font-size:8.46666622px;stroke-width:0.26458332">uart</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="-239.51932"
-       y="173.67091"
-       id="text873"
-       transform="rotate(-90)"><tspan
-         sodipodi:role="line"
-         id="tspan871"
-         x="-239.51932"
-         y="173.67091"
-         style="stroke-width:0.26458332">Drivers</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="-180.73727"
-       y="173.7536"
-       id="text873-3"
-       transform="rotate(-90)"><tspan
-         sodipodi:role="line"
-         id="tspan871-1"
-         x="-180.73727"
-         y="173.7536"
-         style="stroke-width:0.26458332">System</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="-113.25359"
-       y="173.7536"
-       id="text873-3-7"
-       transform="rotate(-90)"><tspan
-         sodipodi:role="line"
-         id="tspan871-1-7"
-         x="-113.25359"
-         y="173.7536"
-         style="stroke-width:0.26458332">User Apps</tspan></text>
-    <rect
-       style="fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5"
-       width="25.830168"
-       height="20.053076"
-       x="56.145214"
-       y="200.88026" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="61.834808"
-       y="213.57799"
-       id="text838-5"><tspan
-         sodipodi:role="line"
-         id="tspan836-4"
-         x="61.834808"
-         y="213.57799"
-         style="font-size:8.46666622px;stroke-width:0.26458332">dac</tspan></text>
-    <rect
-       style="fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6"
-       width="33.848255"
-       height="19.518532"
-       x="86.776451"
-       y="200.91267"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="92.466042"
-       y="213.6104"
-       id="text838-5-8"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6"
-         x="92.466042"
-         y="213.6104"
-         style="font-size:8.46666622px;stroke-width:0.26458332">analog</tspan></text>
-    <rect
-       style="fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-4"
-       width="25.830168"
-       height="20.053076"
-       x="25.559446"
-       y="224.8333" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="34.189007"
-       y="237.26375"
-       id="text838-57"><tspan
-         sodipodi:role="line"
-         id="tspan836-8"
-         x="34.189007"
-         y="237.26375"
-         style="font-size:8.46666622px;stroke-width:0.26458332">io</tspan></text>
-    <rect
-       style="fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-0"
-       width="25.830168"
-       height="20.053076"
-       x="56.15749"
-       y="224.8333" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="60.510735"
-       y="236.32831"
-       id="text838-5-3"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-0"
-         x="60.510735"
-         y="236.32831"
-         style="font-size:8.46666622px;stroke-width:0.26458332">pwm</tspan></text>
-    <rect
-       style="fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-2"
-       width="29.304668"
-       height="19.251255"
-       x="87.590546"
-       y="225.66751"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="92.478333"
-       y="237.42981"
-       id="text838-5-8-1"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-0"
-         x="92.478333"
-         y="237.42981"
-         style="font-size:8.46666622px;stroke-width:0.26458332">timer</tspan></text>
-    <rect
-       style="fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-1"
-       width="27.166521"
-       height="20.587603"
-       x="125.32393"
-       y="200.36194"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="131.01353"
-       y="213.05966"
-       id="text838-5-8-7"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-06"
-         x="131.01353"
-         y="213.05966"
-         style="font-size:8.46666622px;stroke-width:0.26458332">gpio</tspan></text>
-    <rect
-       style="fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-2-2"
-       width="37.590023"
-       height="19.518524"
-       x="120.39173"
-       y="225.25043"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="124.47771"
-       y="237.14635"
-       id="text838-5-8-1-7"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-0-6"
-         x="124.47771"
-         y="237.14635"
-         style="font-size:8.46666622px;stroke-width:0.26458332">encoder</tspan></text>
-    <rect
-       style="fill:#aaccff;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-2-2-8"
-       width="47.211723"
-       height="18.983986"
-       x="33.857098"
-       y="142.11339"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="37.943066"
-       y="154.00931"
-       id="text838-5-8-1-7-2"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-0-6-7"
-         x="37.943066"
-         y="154.00931"
-         style="font-size:8.46666622px;stroke-width:0.26458332">commands</tspan></text>
-    <rect
-       style="fill:#aaccff;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-2-2-8-6"
-       width="31.175556"
-       height="19.785788"
-       x="48.556908"
-       y="165.09856"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="52.642876"
-       y="176.99448"
-       id="text838-5-8-1-7-2-8"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-0-6-7-5"
-         x="52.642876"
-         y="176.99448"
-         style="font-size:8.46666622px;stroke-width:0.26458332">debug</tspan></text>
-    <rect
-       style="fill:#aaccff;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-2-2-8-7"
-       width="44.806297"
-       height="18.983994"
-       x="83.970123"
-       y="165.63312"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="88.056091"
-       y="177.52904"
-       id="text838-5-8-1-7-2-1"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-0-6-7-4"
-         x="88.056091"
-         y="177.52904"
-         style="font-size:8.46666622px;stroke-width:0.26458332">scheduler</tspan></text>
-    <rect
-       style="fill:#aaccff;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-2-2-8-6-7"
-       width="19.415693"
-       height="19.518513"
-       x="86.375542"
-       y="142.11339"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="90.46151"
-       y="154.00931"
-       id="text838-5-8-1-7-2-8-1"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-0-6-7-5-1"
-         x="90.46151"
-         y="154.00931"
-         style="font-size:8.46666622px;stroke-width:0.26458332">log</tspan></text>
-    <rect
-       style="fill:#aaccff;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-2-2-8-6-6"
-       width="31.175556"
-       height="19.785788"
-       x="110.56344"
-       y="142.24702"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="115.45122"
-       y="153.87567"
-       id="text838-5-8-1-7-2-8-4"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-0-6-7-5-5"
-         x="115.45122"
-         y="153.87567"
-         style="font-size:8.46666622px;stroke-width:0.26458332">serial</tspan></text>
-    <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 20.312484,134.23285 V 47.102982"
-       id="path1120"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 161.69806,192.97072 v 61.80069"
-       id="path1122"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 161.69806,254.77141 H 20.291831"
-       id="path1124"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 20.312484,192.97072 v 61.73387"
-       id="path1126"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 20.312484,192.97072 V 134.23285"
-       id="path1128"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 161.69806,192.97072 V 134.23285"
-       id="path1130"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 161.69806,134.23285 V 47.102985"
-       id="path1120-8"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 20.312484,47.102982 H 161.66634"
-       id="path1147"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 67.441006,134.7329 V 47.603027"
-       id="path1120-2"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 114.56953,134.7329 V 47.603027"
-       id="path1120-2-8"
-       inkscape:connector-curvature="0" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="35.284679"
-       y="55.277779"
-       id="text873-3-7-7"><tspan
-         sodipodi:role="line"
-         id="tspan871-1-7-2"
-         x="35.284679"
-         y="55.277779"
-         style="font-size:7.05555534px;stroke-width:0.26458332">App 1</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="82.421814"
-       y="55.277779"
-       id="text873-3-7-7-3"><tspan
-         sodipodi:role="line"
-         id="tspan871-1-7-2-1"
-         x="82.421814"
-         y="55.277779"
-         style="font-size:7.05555534px;stroke-width:0.26458332">App 2</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="129.54861"
-       y="55.277779"
-       id="text873-3-7-7-35"><tspan
-         sodipodi:role="line"
-         id="tspan871-1-7-2-9"
-         x="129.54861"
-         y="55.277779"
-         style="font-size:7.05555534px;stroke-width:0.26458332">App 3</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="-283.90204"
-       y="174.01198"
-       id="text873-4"
-       transform="rotate(-90)"><tspan
-         sodipodi:role="line"
-         id="tspan871-8"
-         x="-283.90204"
-         y="174.01198"
-         style="stroke-width:0.26458332">H/W</tspan></text>
-    <rect
-       style="display:inline;fill:#afe9af;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-2-2-8-6-6-4"
-       width="31.175556"
-       height="19.785788"
-       x="28.048388"
-       y="109.43796"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="36.002522"
-       y="122.25574"
-       id="text838-5-8-1-7-2-8-4-6"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-0-6-7-5-5-4"
-         x="36.002522"
-         y="122.25574"
-         style="font-size:8.46666622px;stroke-width:0.26458332">task</tspan></text>
-    <rect
-       style="display:inline;fill:#afe9af;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-2-2-8-6-6-4-8"
-       width="31.175556"
-       height="19.785788"
-       x="28.048388"
-       y="85.885704"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="33.677082"
-       y="98.703484"
-       id="text838-5-8-1-7-2-8-4-6-1"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-0-6-7-5-5-4-1"
-         x="33.677082"
-         y="98.703484"
-         style="font-size:8.46666622px;stroke-width:0.26458332">cmd2</tspan></text>
-    <rect
-       style="display:inline;fill:#afe9af;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-2-2-8-6-6-4-5"
-       width="31.175556"
-       height="19.785788"
-       x="28.048388"
-       y="62.333435"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="33.666748"
-       y="75.151215"
-       id="text838-5-8-1-7-2-8-4-6-8"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-0-6-7-5-5-4-6"
-         x="33.666748"
-         y="75.151215"
-         style="font-size:8.46666622px;stroke-width:0.26458332">cmd1</tspan></text>
-    <rect
-       style="display:inline;fill:#afe9af;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-2-2-8-6-6-4-6"
-       width="31.175556"
-       height="19.785788"
-       x="75.283859"
-       y="109.67269"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="81.251556"
-       y="122.49047"
-       id="text838-5-8-1-7-2-8-4-6-9"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-0-6-7-5-5-4-5"
-         x="81.251556"
-         y="122.49047"
-         style="font-size:8.46666622px;stroke-width:0.26458332">task2</tspan></text>
-    <rect
-       style="display:inline;fill:#afe9af;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-2-2-8-6-6-4-8-9"
-       width="31.175556"
-       height="19.785788"
-       x="75.283859"
-       y="86.12043"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="81.241219"
-       y="98.93821"
-       id="text838-5-8-1-7-2-8-4-6-1-1"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-0-6-7-5-5-4-1-4"
-         x="81.241219"
-         y="98.93821"
-         style="font-size:8.46666622px;stroke-width:0.26458332">task1</tspan></text>
-    <rect
-       style="display:inline;fill:#afe9af;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect834-5-6-2-2-8-6-6-4-7"
-       width="31.175556"
-       height="19.785788"
-       x="122.85784"
-       y="109.13814"
-       ry="0.26726952" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="130.81197"
-       y="121.95592"
-       id="text838-5-8-1-7-2-8-4-6-5"><tspan
-         sodipodi:role="line"
-         id="tspan836-4-6-0-6-7-5-5-4-7"
-         x="130.81197"
-         y="121.95592"
-         style="font-size:8.46666622px;stroke-width:0.26458332">cmd</tspan></text>
-  </g>
+     transform="translate(60.880295,-36.595864)" />
   <g
      inkscape:groupmode="layer"
      id="layer2"
      inkscape:label="Layer 2"
      style="display:inline"
-     transform="translate(60.880295,-36.595864)">
-    <rect
-       style="fill:#ffeeaa;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect1339"
-       width="70.69278"
-       height="35.425022"
-       x="20.312483"
-       y="254.77141"
-       ry="0.26726884" />
-    <rect
-       style="display:inline;fill:#ffeeaa;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect1339-7"
-       width="70.69278"
-       height="243.09346"
-       x="-50.380295"
-       y="47.102982"
-       ry="0.26726884" />
-    <rect
-       style="display:inline;fill:#ffeeaa;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
-       id="rect1339-6"
-       width="70.69278"
-       height="35.425022"
-       x="91.00528"
-       y="254.77141"
-       ry="0.26726884" />
-  </g>
+     transform="translate(60.880295,-36.595864)" />
   <g
      inkscape:groupmode="layer"
      id="layer3"
      inkscape:label="Layer 3"
      style="display:inline"
-     transform="translate(60.880295,-36.595864)">
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="-35.724251"
-       y="278.67917"
-       id="text873-4-0"><tspan
-         sodipodi:role="line"
-         id="tspan871-8-8"
-         x="-35.724251"
-         y="278.67917"
-         style="font-size:16.93333244px;stroke-width:0.26458332">FPGA</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="98.956963"
-       y="275.30545"
-       id="text873-4-0-4"><tspan
-         sodipodi:role="line"
-         id="tspan871-8-8-1"
-         x="98.956963"
-         y="275.30545"
-         style="font-size:8.46666622px;stroke-width:0.26458332">ARM Cortex-A9</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="28.264164"
-       y="275.30545"
-       id="text873-4-0-4-3"><tspan
-         sodipodi:role="line"
-         id="tspan871-8-8-1-0"
-         x="28.264164"
-         y="275.30545"
-         style="font-size:8.46666622px;stroke-width:0.26458332">ARM Cortex-A9</tspan></text>
-  </g>
+     transform="translate(60.880295,-36.595864)" />
   <g
      inkscape:groupmode="layer"
      id="layer4"
      inkscape:label="Layer 4"
      transform="translate(-19.334995,-90)">
     <g
-       id="g1027">
-      <rect
-         y="284.77344"
-         x="46.616161"
-         height="19.675125"
-         width="35.468559"
-         id="rect834-5-5"
-         style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
-      <text
-         id="text838-5-7"
-         y="297.43253"
-         x="52.324303"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-         xml:space="preserve"><tspan
-           style="font-size:8.46666622px;stroke-width:0.26458332"
-           y="297.43253"
-           x="52.324303"
-           id="tspan836-4-1"
-           sodipodi:role="line">timer2</tspan></text>
-    </g>
-    <g
-       id="g1032"
-       transform="translate(0.09448624,-1.1339101)">
-      <rect
-         y="251.7005"
-         x="46.521675"
-         height="19.675125"
-         width="35.468559"
-         id="rect834-5-5-6"
-         style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
-      <text
-         id="text838-5-7-9"
-         y="264.35959"
-         x="52.219482"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-         xml:space="preserve"><tspan
-           style="font-size:8.46666622px;stroke-width:0.26458332"
-           y="264.35959"
-           x="52.219482"
-           id="tspan836-4-1-4"
-           sodipodi:role="line">timer1</tspan></text>
-    </g>
-    <g
-       id="g1037"
-       transform="translate(-0.83094025,1.1523844)">
-      <rect
-         y="215.20735"
-         x="47.447102"
-         height="19.675125"
-         width="35.468559"
-         id="rect834-5-5-9"
-         style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
-      <text
-         id="text838-5-7-0"
-         y="227.9698"
-         x="58.79211"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-         xml:space="preserve"><tspan
-           style="font-size:8.46666622px;stroke-width:0.26458332"
-           y="227.9698"
-           x="58.79211"
-           id="tspan836-4-1-2"
-           sodipodi:role="line">dac</tspan></text>
-    </g>
-    <g
        id="g1042"
-       transform="translate(-0.85044861,0.75597776)">
+       transform="translate(-18.993305,-81.330827)">
+      <g
+         id="g2240-38-4-0"
+         transform="translate(37.453352,-5.8052766)">
+        <g
+           id="g3178-0">
+          <rect
+             y="177.34541"
+             x="44.894157"
+             height="6.4241061"
+             width="17.136631"
+             id="rect834-5-5-1-3-0-8"
+             style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        </g>
+      </g>
       <rect
-         y="181.39691"
-         x="47.46661"
-         height="19.675125"
-         width="35.468559"
-         id="rect834-5-5-1"
-         style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+         style="opacity:1;fill:#ffeeaa;stroke:#000000;stroke-width:0.2;stroke-linecap:round;stroke-dasharray:none"
+         id="rect3218"
+         width="16.905737"
+         height="50.698578"
+         x="38.428299"
+         y="171.43083" />
+      <g
+         id="g2240"
+         transform="translate(-7.2601166,-15.834846)">
+        <rect
+           y="189.80688"
+           x="48.364304"
+           height="4.6033301"
+           width="11.457153"
+           id="rect834-5-5-1"
+           style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text838-5-7-00"
+           y="193.0218"
+           x="53.988152"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+             y="193.0218"
+             x="53.988152"
+             id="tspan836-4-1-1"
+             sodipodi:role="line">adc</tspan></text>
+      </g>
+      <g
+         id="g2240-3"
+         transform="translate(-7.2601166,-9.677922)">
+        <rect
+           y="189.80688"
+           x="48.364304"
+           height="4.6033301"
+           width="11.457153"
+           id="rect834-5-5-1-2"
+           style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text838-5-7-00-8"
+           y="193.0218"
+           x="53.988152"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+             y="193.0218"
+             x="53.988152"
+             id="tspan836-4-1-1-7"
+             sodipodi:role="line">pwm</tspan></text>
+      </g>
+      <g
+         id="g2240-6"
+         transform="translate(-7.2601166,-3.5209981)">
+        <rect
+           y="189.80688"
+           x="48.364304"
+           height="4.6033301"
+           width="11.457153"
+           id="rect834-5-5-1-7"
+           style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text838-5-7-00-9"
+           y="193.0218"
+           x="53.988152"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+             y="193.0218"
+             x="53.988152"
+             id="tspan836-4-1-1-0"
+             sodipodi:role="line">encoder</tspan></text>
+      </g>
+      <g
+         id="g2240-5"
+         transform="translate(-7.2601166,2.6359259)">
+        <rect
+           y="189.80688"
+           x="48.364304"
+           height="4.6033301"
+           width="11.457153"
+           id="rect834-5-5-1-5"
+           style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text838-5-7-00-0"
+           y="193.0218"
+           x="53.988152"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+             y="193.0218"
+             x="53.988152"
+             id="tspan836-4-1-1-72"
+             sodipodi:role="line">dac</tspan></text>
+      </g>
+      <g
+         id="g2240-61"
+         transform="translate(-7.2601166,8.7928499)">
+        <rect
+           y="189.80688"
+           x="48.364304"
+           height="4.6033301"
+           width="11.457153"
+           id="rect834-5-5-1-0"
+           style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text838-5-7-00-2"
+           y="193.0218"
+           x="53.988152"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+             y="193.0218"
+             x="53.988152"
+             id="tspan836-4-1-1-9"
+             sodipodi:role="line">timer</tspan></text>
+      </g>
+      <g
+         id="g2240-38"
+         transform="translate(-7.2601166,14.949774)">
+        <rect
+           y="189.80688"
+           x="48.364304"
+           height="4.6033301"
+           width="11.457153"
+           id="rect834-5-5-1-3"
+           style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text838-5-7-00-88"
+           y="193.0218"
+           x="53.988152"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+             y="193.0218"
+             x="53.988152"
+             id="tspan836-4-1-1-6"
+             sodipodi:role="line">gpio</tspan></text>
+      </g>
+      <g
+         id="g2240-38-4"
+         transform="translate(-4.8546906,31.663842)">
+        <g
+           id="g3178">
+          <rect
+             y="179.24974"
+             x="45.958878"
+             height="4.6033301"
+             width="11.457153"
+             id="rect834-5-5-1-3-0"
+             style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+          <text
+             id="text838-5-7-00-88-9"
+             y="182.46466"
+             x="51.582726"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+             xml:space="preserve"><tspan
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+               y="182.46466"
+               x="51.582726"
+               id="tspan836-4-1-1-6-2"
+               sodipodi:role="line">amds</tspan></text>
+        </g>
+      </g>
       <text
-         id="text838-5-7-00"
-         y="194.15935"
-         x="50.340816"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-         xml:space="preserve"><tspan
-           style="font-size:8.46666622px;stroke-width:0.26458332"
-           y="194.15935"
-           x="50.340816"
-           id="tspan836-4-1-1"
-           sodipodi:role="line">encoder</tspan></text>
-    </g>
-    <g
-       id="g1047"
-       transform="translate(-0.85045624,1.1339424)">
-      <rect
-         y="146.81209"
-         x="47.466618"
-         height="19.675125"
-         width="35.468559"
-         id="rect834-5-5-7"
-         style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:3.52778px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="42.314518"
+         y="220.04175"
+         id="text4234"><tspan
+           sodipodi:role="line"
+           id="tspan4232"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+           x="42.314518"
+           y="220.04175">FPGA</tspan></text>
+      <g
+         id="g4456"
+         transform="translate(6.7861226,0.0999999)">
+        <rect
+           style="fill:#ffeeaa;stroke:#000000;stroke-width:0.2;stroke-linecap:round;stroke-dasharray:none"
+           id="rect3218-0"
+           width="28.692474"
+           height="6.513916"
+           x="55.337227"
+           y="215.61691" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:3.52778px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="57.416706"
+           y="220.06221"
+           id="text4234-0"><tspan
+             sodipodi:role="line"
+             id="tspan4232-6"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+             x="57.416706"
+             y="220.06221">ARM Cortex-A9</tspan></text>
+      </g>
+      <g
+         id="g4456-2"
+         transform="translate(35.4786,0.0999999)">
+        <rect
+           style="fill:#ffeeaa;stroke:#000000;stroke-width:0.2;stroke-linecap:round;stroke-dasharray:none"
+           id="rect3218-0-2"
+           width="28.692474"
+           height="6.513916"
+           x="55.337227"
+           y="215.61691" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:3.52778px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="57.416706"
+           y="220.06221"
+           id="text4234-0-0"><tspan
+             sodipodi:role="line"
+             id="tspan4232-6-7"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+             x="57.416706"
+             y="220.06221">ARM Cortex-A9</tspan></text>
+      </g>
+      <path
+         style="fill:#000000;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleStart);marker-end:url(#marker5173)"
+         d="m 55.337227,218.87386 h 6.786122"
+         id="path4905"
+         sodipodi:nodetypes="cc" />
       <text
-         id="text838-5-7-6"
-         y="157.76999"
-         x="56.056236"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-         xml:space="preserve"><tspan
-           style="font-size:8.46666622px;stroke-width:0.26458332"
-           y="157.76999"
-           x="56.056236"
-           id="tspan836-4-1-5"
-           sodipodi:role="line">pwm</tspan></text>
-    </g>
-    <g
-       id="g1052"
-       transform="translate(-0.85044861)">
-      <rect
-         y="113.73918"
-         x="47.46661"
-         height="19.675125"
-         width="35.468559"
-         id="rect834-5-5-5"
-         style="display:inline;fill:#fff6d5;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:2.11667px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="56.348518"
+         y="216.67627"
+         id="text5770"><tspan
+           sodipodi:role="line"
+           id="tspan5768"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+           x="56.348518"
+           y="216.67627">AXI4</tspan></text>
+      <g
+         id="g22668">
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="44.858505"
+           y="226.23514"
+           id="text4546"><tspan
+             sodipodi:role="line"
+             id="tspan4544"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+             x="44.858505"
+             y="226.23514">Hardware</tspan></text>
+        <rect
+           style="fill:#ffeeaa;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-dasharray:none"
+           id="rect6994"
+           width="5.0116839"
+           height="2.3891754"
+           x="38.757469"
+           y="223.95363" />
+      </g>
+      <g
+         id="g22663"
+         transform="translate(0.52916667)">
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="66.699875"
+           y="226.23514"
+           id="text4546-5"><tspan
+             sodipodi:role="line"
+             id="tspan4544-3"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+             x="66.699875"
+             y="226.23514">Drivers</tspan></text>
+        <rect
+           style="fill:#ffd5d5;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-dasharray:none"
+           id="rect6994-3"
+           width="5.0116839"
+           height="2.3891754"
+           x="60.598839"
+           y="223.95363" />
+      </g>
+      <g
+         id="g22658"
+         transform="translate(1.0583333)">
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="85.671898"
+           y="226.1869"
+           id="text4546-5-4"><tspan
+             sodipodi:role="line"
+             id="tspan4544-3-2"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+             x="85.671898"
+             y="226.1869">System</tspan></text>
+        <rect
+           style="fill:#aaccff;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-dasharray:none"
+           id="rect6994-3-3"
+           width="5.0116839"
+           height="2.3891754"
+           x="79.570862"
+           y="223.95363" />
+      </g>
+      <g
+         id="g22653"
+         transform="translate(1.5875)">
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="104.3082"
+           y="226.1869"
+           id="text4546-5-4-7"><tspan
+             sodipodi:role="line"
+             id="tspan4544-3-2-8"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+             x="104.3082"
+             y="226.1869">User Apps</tspan></text>
+        <rect
+           style="fill:#afe9af;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-dasharray:none"
+           id="rect6994-3-3-9"
+           width="5.0116839"
+           height="2.3891754"
+           x="98.207169"
+           y="223.95363" />
+      </g>
+      <g
+         id="g15309"
+         transform="translate(0.19080983,0.30351135)">
+        <rect
+           y="209.46376"
+           x="63.451115"
+           height="4.7033272"
+           width="5.9764948"
+           id="rect834-5-5-1-3-4"
+           style="display:inline;fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text838-5-7-00-88-95"
+           y="212.77591"
+           x="66.435226"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+             y="212.77591"
+             x="66.435226"
+             id="tspan836-4-1-1-6-4"
+             sodipodi:role="line">adc</tspan></text>
+      </g>
+      <g
+         id="g15309-5"
+         transform="translate(7.2841222,0.30351135)">
+        <g
+           id="g15420">
+          <rect
+             y="209.46376"
+             x="63.451115"
+             height="4.7033272"
+             width="5.9764948"
+             id="rect834-5-5-1-3-4-88"
+             style="display:inline;fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+          <text
+             id="text838-5-7-00-88-95-4"
+             y="212.77591"
+             x="66.438675"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+             xml:space="preserve"><tspan
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+               y="212.77591"
+               x="66.438675"
+               id="tspan836-4-1-1-6-4-99"
+               sodipodi:role="line">dac</tspan></text>
+        </g>
+      </g>
+      <g
+         id="g15309-5-1"
+         transform="translate(9.3160642,-6.5410837)">
+        <g
+           id="g15420-6">
+          <g
+             id="g15656"
+             transform="translate(0.24371753,0.94494047)">
+            <g
+               id="g15661">
+              <rect
+                 y="209.46376"
+                 x="63.451115"
+                 height="4.7033234"
+                 width="7.2049203"
+                 id="rect834-5-5-1-3-4-88-1"
+                 style="display:inline;fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+              <text
+                 id="text838-5-7-00-88-95-4-1"
+                 y="212.40909"
+                 x="67.064598"
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+                 xml:space="preserve"><tspan
+                   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+                   y="212.40909"
+                   x="67.064598"
+                   id="tspan836-4-1-1-6-4-99-7"
+                   sodipodi:role="line">pwm</tspan></text>
+            </g>
+          </g>
+        </g>
+      </g>
+      <g
+         id="g15676"
+         transform="translate(0.27227088,5.2244465)">
+        <rect
+           y="204.64282"
+           x="77.567825"
+           height="4.6033301"
+           width="11.457153"
+           id="rect834-5-5-1-3-4-8-1"
+           style="display:inline;fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text838-5-7-00-88-95-9-4"
+           y="207.85774"
+           x="83.191673"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+             y="207.85774"
+             x="83.191673"
+             id="tspan836-4-1-1-6-4-5-8"
+             sodipodi:role="line">encoder</tspan></text>
+      </g>
+      <g
+         id="g15671"
+         transform="translate(-0.56258038,5.3521981)">
+        <rect
+           y="198.56541"
+           x="81.612534"
+           height="4.6033325"
+           width="8.2472963"
+           id="rect834-5-5-1-3-4-8-1-4-4"
+           style="display:inline;fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text838-5-7-00-88-95-9-4-0-4"
+           y="201.68585"
+           x="85.696014"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+             y="201.68585"
+             x="85.696014"
+             id="tspan836-4-1-1-6-4-5-8-1-7"
+             sodipodi:role="line">timer</tspan></text>
+      </g>
+      <g
+         id="g15666"
+         transform="translate(-4.5820933,3.4485268)">
+        <rect
+           y="200.46909"
+           x="68.301086"
+           height="4.6033325"
+           width="8.2695599"
+           id="rect834-5-5-1-3-4-8-1-4-4-7"
+           style="display:inline;fill:#ffd5d5;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text838-5-7-00-88-95-9-4-0-4-2"
+           y="203.73125"
+           x="72.428894"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+             y="203.73125"
+             x="72.428894"
+             id="tspan836-4-1-1-6-4-5-8-1-7-4"
+             sodipodi:role="line">amds</tspan></text>
+      </g>
+      <g
+         id="g15984"
+         transform="translate(0.55868314,6.8236929)">
+        <g
+           id="g15994">
+          <rect
+             y="191.24426"
+             x="63.243561"
+             height="4.6033325"
+             width="11.717012"
+             id="rect834-5-5-1-3-4-4"
+             style="display:inline;fill:#aaccff;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+          <text
+             id="text838-5-7-00-88-95-5"
+             y="194.55595"
+             x="69.066925"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+             xml:space="preserve"><tspan
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+               y="194.55595"
+               x="69.066925"
+               id="tspan836-4-1-1-6-4-9"
+               sodipodi:role="line">injection</tspan></text>
+        </g>
+      </g>
+      <g
+         id="g15974"
+         transform="translate(15.567595,-0.67072412)">
+        <g
+           id="g16624">
+          <rect
+             y="193.03076"
+             x="63.208618"
+             height="4.6033325"
+             width="10.521036"
+             id="rect834-5-5-1-3-4-4-8"
+             style="display:inline;fill:#aaccff;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+          <text
+             id="text838-5-7-00-88-95-5-1"
+             y="196.00766"
+             x="68.600365"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+             xml:space="preserve"><tspan
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+               y="196.00766"
+               x="68.600365"
+               id="tspan836-4-1-1-6-4-9-3"
+               sodipodi:role="line">logging</tspan></text>
+        </g>
+        <rect
+           style="opacity:1;fill:#7c6868;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-dasharray:0.600001, 0.600001;stroke-dashoffset:0"
+           id="rect16619"
+           width="0.55857319"
+           height="0.0015602603"
+           x="63.71912"
+           y="193.03076" />
+      </g>
+      <g
+         id="g14661"
+         transform="translate(-0.29614213,0.60637365)">
+        <g
+           id="g21868">
+          <rect
+             y="182.86353"
+             x="93.294205"
+             height="30.424221"
+             width="24.328003"
+             id="rect834-5-5-1-3-4-4-6"
+             style="display:inline;fill:#aaccff;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+          <text
+             id="text838-5-7-00-88-95-5-5"
+             y="193.91222"
+             x="105.4651"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+             xml:space="preserve"><tspan
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+               y="193.91222"
+               x="105.4651"
+               id="tspan836-4-1-1-6-4-9-2"
+               sodipodi:role="line">lwIP</tspan><tspan
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+               y="197.99428"
+               x="105.4651"
+               sodipodi:role="line"
+               id="tspan14653" /><tspan
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+               y="201.56499"
+               x="105.4651"
+               sodipodi:role="line"
+               id="tspan12797">TCP/IP</tspan><tspan
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+               y="205.13568"
+               x="105.4651"
+               sodipodi:role="line"
+               id="tspan12801">Stack</tspan></text>
+        </g>
+      </g>
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.6, 0.6;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 90.815825,215.7169 0,-37.85554"
+         id="path10340"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleStart-7);marker-end:url(#marker5173-1)"
+         d="m 87.422763,175.44438 h 6.786125"
+         id="path4905-8"
+         sodipodi:nodetypes="cc" />
       <text
-         id="text838-5-7-5"
-         y="125.61073"
-         x="53.083797"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-         xml:space="preserve"><tspan
-           style="font-size:8.46666622px;stroke-width:0.26458332"
-           y="125.61073"
-           x="53.083797"
-           id="tspan836-4-1-9"
-           sodipodi:role="line">analog</tspan></text>
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:2.11667px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="83.171318"
+         y="173.3817"
+         id="text5770-1"><tspan
+           sodipodi:role="line"
+           id="tspan5768-3"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+           x="83.171318"
+           y="173.3817">On-Chip Memory</tspan></text>
+      <g
+         id="g15979"
+         transform="translate(-11.844088,1.9009944)">
+        <rect
+           y="190.45905"
+           x="75.646332"
+           height="4.6033325"
+           width="13.750917"
+           id="rect834-5-5-1-3-4-4-7"
+           style="display:inline;fill:#aaccff;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text838-5-7-00-88-95-5-7"
+           y="193.72121"
+           x="82.423004"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+             y="193.72121"
+             x="82.423004"
+             id="tspan836-4-1-1-6-4-9-9"
+             sodipodi:role="line">commands</tspan></text>
+      </g>
+      <g
+         id="g15969"
+         transform="translate(2.3772494,4.8191964)">
+        <g
+           id="g15989">
+          <rect
+             y="193.21706"
+             x="74.236107"
+             height="4.6033325"
+             width="12.683891"
+             id="rect834-5-5-1-3-4-4-75"
+             style="display:inline;fill:#aaccff;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+          <text
+             id="text838-5-7-00-88-95-5-75"
+             y="196.45816"
+             x="80.500191"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+             xml:space="preserve"><tspan
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+               y="196.45816"
+               x="80.500191"
+               id="tspan836-4-1-1-6-4-9-1"
+               sodipodi:role="line">scheduler</tspan></text>
+        </g>
+      </g>
+      <g
+         id="g17600">
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.6, 0.6;stroke-dashoffset:0;stroke-opacity:1"
+           d="M 119.5083,215.71691 V 171.33084"
+           id="path10340-4-0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.6, 0.6;stroke-dashoffset:0;stroke-opacity:1"
+           d="M 119.6083,171.43725 H 99.384141"
+           id="path10340-4-0-9"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <g
+         id="g17600-3"
+         transform="matrix(-1,0,0,1,181.63165,2.7417969e-6)">
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.6, 0.6;stroke-dashoffset:0;stroke-opacity:1"
+           d="M 119.5083,215.71691 V 171.33084"
+           id="path10340-4-0-8"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:0.6, 0.6;stroke-dashoffset:0;stroke-opacity:1"
+           d="M 119.6083,171.43725 H 99.384141"
+           id="path10340-4-0-9-8"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <g
+         id="g21480"
+         transform="translate(-0.02825278,0.00661255)">
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-dasharray:none;stroke-dashoffset:0"
+           id="rect17944-3-6"
+           width="13.789581"
+           height="17.02523"
+           x="65.340637"
+           y="172.57355" />
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-dasharray:none;stroke-dashoffset:0"
+           id="rect17944-3"
+           width="13.789581"
+           height="17.02523"
+           x="64.669907"
+           y="173.38603" />
+        <g
+           id="g21434">
+          <rect
+             style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-dasharray:none;stroke-dashoffset:0"
+             id="rect17944"
+             width="13.789581"
+             height="17.02523"
+             x="63.863579"
+             y="174.18529" />
+          <g
+             id="g21391">
+            <g
+               id="g20171"
+               transform="translate(0.88693528,-2.0025152)">
+              <g
+                 id="g16781-0-2-3"
+                 transform="translate(3.178817,-7.7779518)">
+                <g
+                   id="g17949-6-7-2"
+                   transform="translate(-0.58530838,0.66145833)">
+                  <g
+                     id="g18361-1-2">
+                    <g
+                       id="g20058-5-0">
+                      <rect
+                         y="186.99846"
+                         x="63.674591"
+                         height="3.9654977"
+                         width="8.8193283"
+                         id="rect834-5-5-1-3-4-4-3-0-8-5-7"
+                         style="display:inline;fill:#afe9af;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+              <g
+                 id="g16781-0-2"
+                 transform="translate(2.4005659,-6.893122)">
+                <g
+                   id="g17949-6-7"
+                   transform="translate(-0.58530838,0.66145833)">
+                  <g
+                     id="g18361-1">
+                    <g
+                       id="g20058-5">
+                      <rect
+                         y="186.99846"
+                         x="63.674591"
+                         height="3.9654977"
+                         width="8.8193283"
+                         id="rect834-5-5-1-3-4-4-3-0-8-5"
+                         style="display:inline;fill:#afe9af;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+              <g
+                 id="g16781-0"
+                 transform="translate(1.5661586,-5.9803658)">
+                <g
+                   id="g17949-6"
+                   transform="translate(-0.58530838,0.66145833)">
+                  <g
+                     id="g18361">
+                    <g
+                       id="g20058">
+                      <rect
+                         y="186.99846"
+                         x="63.674591"
+                         height="3.9654977"
+                         width="8.8193283"
+                         id="rect834-5-5-1-3-4-4-3-0-8"
+                         style="display:inline;fill:#afe9af;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+                      <text
+                         id="text838-5-7-00-88-95-5-6-0-9"
+                         y="189.9417"
+                         x="68.208282"
+                         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+                         xml:space="preserve"><tspan
+                           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+                           y="189.9417"
+                           x="68.208282"
+                           id="tspan836-4-1-1-6-4-9-4-3-8"
+                           sodipodi:role="line">cmd</tspan></text>
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+            <g
+               id="g20171-9"
+               transform="translate(0.88693482,4.73986)">
+              <g
+                 id="g16781-0-6"
+                 transform="translate(1.5661586,-5.9803658)">
+                <g
+                   id="g17949-6-0"
+                   transform="translate(-0.58530838,0.66145833)">
+                  <g
+                     id="g18361-3">
+                    <g
+                       id="g20058-56">
+                      <g
+                         id="g20546">
+                        <g
+                           id="g16781-0-2-3-0"
+                           transform="translate(2.1979677,-2.459045)">
+                          <g
+                             id="g17949-6-7-2-1"
+                             transform="translate(-0.58530838,0.66145833)">
+                            <g
+                               id="g18361-1-2-5">
+                              <g
+                                 id="g20058-5-0-7">
+                                <rect
+                                   y="186.99846"
+                                   x="63.674591"
+                                   height="3.9654977"
+                                   width="8.8193283"
+                                   id="rect834-5-5-1-3-4-4-3-0-8-5-7-6"
+                                   style="display:inline;fill:#afe9af;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+                              </g>
+                            </g>
+                          </g>
+                        </g>
+                        <g
+                           id="g16781-0-2-9"
+                           transform="translate(1.419717,-1.5742148)">
+                          <g
+                             id="g17949-6-7-0"
+                             transform="translate(-0.58530838,0.66145833)">
+                            <g
+                               id="g18361-1-3">
+                              <g
+                                 id="g20058-5-7">
+                                <rect
+                                   y="186.99846"
+                                   x="63.674591"
+                                   height="3.9654977"
+                                   width="8.8193283"
+                                   id="rect834-5-5-1-3-4-4-3-0-8-5-76"
+                                   style="display:inline;fill:#afe9af;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+                              </g>
+                            </g>
+                          </g>
+                        </g>
+                        <rect
+                           y="186.99846"
+                           x="63.674591"
+                           height="3.9654977"
+                           width="8.8193283"
+                           id="rect834-5-5-1-3-4-4-3-0-8-2"
+                           style="display:inline;fill:#afe9af;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+                        <text
+                           id="text838-5-7-00-88-95-5-6-0-9-5"
+                           y="189.9417"
+                           x="68.208282"
+                           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+                           xml:space="preserve"><tspan
+                             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:center;text-anchor:middle;stroke-width:0.264583"
+                             y="189.9417"
+                             x="68.208282"
+                             id="tspan836-4-1-1-6-4-9-4-3-8-0"
+                             sodipodi:role="line">task</tspan></text>
+                      </g>
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+            <text
+               xml:space="preserve"
+               style="font-style:normal;font-weight:normal;font-size:2.11667px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+               x="66.681038"
+               y="176.54213"
+               id="text18522"><tspan
+                 sodipodi:role="line"
+                 id="tspan18520"
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.11667px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+                 x="66.681038"
+                 y="176.54213">User App</tspan></text>
+          </g>
+        </g>
+      </g>
     </g>
   </g>
 </svg>

--- a/source/firmware/arch/index.md
+++ b/source/firmware/arch/index.md
@@ -9,7 +9,14 @@ This document outlines the AMDC firmware architecture. By understanding the high
 
 A good software system has many layers of abstraction. The client of one subsystem does not need to know how that subsystem works interally -- she/he simply uses the interface provided and expects that it works as specified. The AMDC firmware is structured in this manner.
 
-![block-diagram](images/block-diagram.svg)
+<br/>
+
+```{figure} images/block-diagram.svg
+:alt: block-diagram
+:figwidth: 100%
+:width: 600px
+:align: left
+```
 
 
 ## Hardware


### PR DESCRIPTION
Replace the old block diagram with a new one that reflects the current state of the firmware architecture.

![image](https://user-images.githubusercontent.com/20168990/228592372-7a62fd48-1344-4d65-9122-973f668ce57c.png)

Notable changes:
- Show that one core runs `lwIP` and one core runs user code
- Show communication mechanisms between hardware resources
   - `On-Chip Memory` between ARM cores
   - `AXI4` between FPGA and ARM core

I rendered the new page locally and it looks good.