### PR TITLE
Add spec tables from IEMDC paper

### DIFF
--- a/source/accessories/amds/sensor-cards/index.md
+++ b/source/accessories/amds/sensor-cards/index.md
@@ -1,13 +1,18 @@
 # Sensor Cards
 
-Three sensor card designs are available.
-
+Three sensor cards are available.
 Users are welcome and encouraged to design addition sensor cards.
 
-| [High Voltage](./high-voltage/index.md) | [Low Voltage](./low-voltage/index.md) | [Current](./current/index.md) |
-| --- | --- | --- |
-| ![](high-voltage/images/amds_hv_card.png) | ![](low-voltage/images/amds_lv_card.png) | ![](current/images/amds_current_card.png) |
+All sensor cards are dc/ac capable with 16-bit ADC.
 
+| Metric | [Current](./current/index.md) | [High Voltage](./high-voltage/index.md) | [Low Voltage](./low-voltage/index.md) |
+| --- | --- | --- | --- |
+| Image | ![](current/images/amds_current_card.png) | ![](high-voltage/images/amds_hv_card.png) | ![](low-voltage/images/amds_lv_card.png) |
+| Sensor Device | LEM LA 55-P | LEM LV 25-P | TI INA143UA |
+| Range (peak) | $\pm$70 A | 10-500 V | $\pm$10 V |
+| Accuracy (\%) | $\pm$0.65 | $\pm$0.8 | $\pm$0.05 |
+| Nonlinearity (\%) | $<$0.15 | $<$0.2 | $<$0.001 |
+| Bandwidth (kHz) | 200 | 25 | 150 |
 
 ```{toctree}
 :hidden:

--- a/source/accessories/uinverter/index.md
+++ b/source/accessories/uinverter/index.md
@@ -1,8 +1,17 @@
-# uInverter
+# μInverter
 
-The uInverter (micro-inverter) board is an accessory for the AMDC.
+The μInverter (micro-inverter) board is an accessory for the AMDC.
 The purpose of this board is to serve as a low-cost, micro-level prototype board to demonstrate three-phase current regulation using the AMDC.
 It uses a 12V DC supply to drive a three phase RL load circuit to emulate a motor.
+
+<br/>
+
+```{image} images/uInverter3D.jpg
+:width: 500px
+:class: align-left
+```
+
+<div style="clear:left;"></div>
 
 ## Features
 
@@ -10,7 +19,30 @@ It uses a 12V DC supply to drive a three phase RL load circuit to emulate a moto
 - Test points to measure voltages at various locations in the supply as well as load circuits.
 - BNC connector to directly measure the current waveforms on an oscilloscope conveniently.
 
-![PCB 3D](images/uInverter3D.jpg)
+## Specifications
+
+<style>
+
+table {
+margin-left: 0 !important;
+margin-right: auto !important;
+width: fit-content !important;
+}
+
+</style>
+
+| Metric | Symbol | Value |
+| --- | --- | --- |
+| Switching Device |   | IXYS IXDN614YI |
+| Current Sensing |   | Shunt + TI INA143 |
+| DC Capacitance | $C_\text{dc}$ | 1000 μF |
+| DC Voltage | $V_\text{dc}$ | 5 to 35 V |
+| Phase Current(rms) | $I_\text{ph}$ | 0 to 4 A |
+| Switching Frequency | $F_\text{sw}$ | 0 to 1 MHz |
+| Effective Load Parameters | $R$, $L$ | 650 mΩ, 120 μH |
+
+- The phase current and switching frequency are limited by the switching device thermal dissipation.
+- The resistance $R$ is given at $V_\text{dc} = 12~\text{V}$.
 
 ```{toctree}
 :hidden:

--- a/source/hardware/index.md
+++ b/source/hardware/index.md
@@ -1,10 +1,33 @@
 # Hardware Overview
 
-The AMDC hardware is a collection of circuit board designs which are used to control advanced motor systems. The hardware design is open-source, modular, and research-oriented.
+**The AMDC hardware is a collection of circuit board designs which are used to control advanced motor systems. The hardware design is open-source, modular, and research-oriented.**
 
-The flagship circuit board is the main AMDC (see latest design [here](https://github.com/Severson-Group/AMDC-Hardware/tree/develop/REV20210325E)) which is a carrier board for the [PicoZed System-on-Module](https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/picozed/). The PicoZed is a module itself which contains the core requirements for the [Xilinx Zynq-7000](https://www.xilinx.com/products/silicon-devices/soc/zynq-7000.html) System-on-Chip. The Xilinx Zynq-7000 SoC is a powerful processor with dual-core DSPs and a tightly integrated FPGA.
+```{image} /hardware/revisions/rev-d/images/amdc-rev-d-cover.jpg
+:width: 250px
+:align: right
+```
 
-Extensive firmware support is provided in the [AMDC-Firmware](https://github.com/Severson-Group/AMDC-Firmware) repo which targets this architecture.
+The AMDC PCB is a carrier board for the [PicoZed System-on-Module](/hardware/subsystems/picozed). The PicoZed is a module PCB which contains the core requirements for the [Xilinx Zynq-7000](https://www.xilinx.com/products/silicon-devices/soc/zynq-7000.html) System-on-Chip. The Xilinx Zynq-7000 SoC is a powerful processor with dual-core DSPs and a tightly integrated FPGA.
+
+<!--Extensive firmware support is provided in the [AMDC-Firmware](https://github.com/Severson-Group/AMDC-Firmware) repo which targets this architecture.-->
+
+<div style="clear:left;"></div>
+
+## Hardware Parameters
+
+These are for the latest hardware revision: `REV20210325E`.
+
+| Parameter | Value | Note |
+| --- | --- | --- |
+| System-on-chip | Xilinx `XC7Z030-1SBG485C` | dual-core ARM Cortex-A9 with Kintex-7 FPGA |
+| Clock frequency (DSP, FPGA) | 666 MHz, 200 MHz | firmware configurable |
+| Nominal input voltage | 24 V | typical 10 W power consumption |
+| Host interface | Ethernet and USB serial | supports 1 Gbps Ethernet |
+| Digital PWM outputs | 48 | arranged for 8 three-phase two-level inverters |
+| Integrated analog inputs | 8 | differential bipolar $\pm$10 V with high CMRR |
+| Encoder inputs | 2 | incremental type (differential `A`, `B`, and `Z` signals) |
+| Expansion ports | 4 | 3/3 differential I/O per port |
+| Approximate unit cost | \$1500 | fully assembled with PicoZed, ordered in quantity 10 |
 
 ## Design Software / Licenses
 


### PR DESCRIPTION
This information is sprinkled around the docs. Now, it is clearly stated in tables.

I rendered locally and believe the formatting looks good.