### PR TITLE
Clarify when to enable task stats

### DIFF
--- a/source/getting-started/tutorials/profiling-tasks/index.md
+++ b/source/getting-started/tutorials/profiling-tasks/index.md
@@ -50,7 +50,14 @@ To do this, update the controller `init()` function:
 int task_controller_init(void)
 {
     // ...
+    
+    // Initialize the TCB struct
+    scheduler_tcb_init(...);
+    
+    // After init of TCB struct,
+    // enable the task stats
     task_stats_enable(&tcb.stats);
+    
     // ...
 }
 


### PR DESCRIPTION
Per a question, clarify when to enable task stats in the task init function.

i.e., AFTER calling the `scheduler_init()` function