### PR TITLE
Update the link to the Xilinx installer

### DIFF
--- a/source/firmware/xilinx-tools/installing-xilinx-tools.md
+++ b/source/firmware/xilinx-tools/installing-xilinx-tools.md
@@ -20,7 +20,7 @@ Ensure you have no Xilinx tools previously installed on your PC (i.e. make sure 
 
 2. Scroll down to the "Vivado Design Suite - HLx Editions  2019.1 Full Product Installation" section for 2019.1
 
-3. It is strongly recommended to use the web installer (you will need to download ~8GB of data). Click on the link for: "Vivado HLx 2019.1: WebPACK and Editions - Windows Self Extracting Web Installer"
+3. Click on the link for: "Vivado HLx 2019.1: All OS installer Single-File Download" (you will need to download ~21.39GB of data).
 
 4. This will make you create a Xilinx account. Do this and continue.
 


### PR DESCRIPTION
This PR updates the AMDC document for the section of Installing Xilinx Tools. Updated document is available in [installing-xilinx-tools.md](https://github.com/Severson-Group/docs.amdc.dev/blob/user/noguchi-takahiro/update-document/source/firmware/xilinx-tools/installing-xilinx-tools.md).

The following change is taking place since the WebPACK installer is currently not available:

- In the Downloading installation executable section, the link of “Vivado HLx 2019.1: WebPACK and Editions - Windows Self Extracting Web Installer” was changed to be "Vivado HLx 2019.1: All OS installer Single-File Download".
- The sentence about an installation size was changed from 8GB to be 21.39GB.

Based on this, I have conducted BLINK tutorial with new grad students and have verified that this change of the installation files do not pose any issues.