### PR TITLE
AMDS documentation tweaks

### DIFF
--- a/source/accessories/amds/mainboard/index.md
+++ b/source/accessories/amds/mainboard/index.md
@@ -146,8 +146,8 @@ One header is used to supply power to the cards and the other header is used for
 | 2 | 3V3 |
 | 3 | GND |
 | 4 | DIN (ADC IN, MOSI) |
-| 5 | DOUT (ADC OUT, MISO) |
-| 6 | SCLK |
+| 5 | SCLK |
+| 6 | DOUT (ADC OUT, MISO) |
 | 7 | CONVST (Conversion start) |
 
 For information regarding the placement of the headers, refer to the mainboard PCB Altium file in the AMDS repo located: `/Mainboard/altium/SensorMotherBoard.PcbDoc`. 

--- a/source/getting-started/user-guide/amds-interface/index.md
+++ b/source/getting-started/user-guide/amds-interface/index.md
@@ -8,7 +8,7 @@ Before attempting to use these drivers, make sure to read about the AMDS in [its
 
 ## AMDS Firmware Version
 
-Ensure that your AMDS Firmware version matches your AMDC firmware version using the following table:
+Ensure that your AMDS firmware version matches your AMDC firmware version using the following table:
 
 | AMDC Version | AMDS Version |
 |-------|-------|

--- a/source/getting-started/user-guide/amds-interface/index.md
+++ b/source/getting-started/user-guide/amds-interface/index.md
@@ -12,8 +12,8 @@ Ensure that your AMDS Firmware version matches your AMDC firmware version using 
 
 | AMDC Version | AMDS Version |
 |-------|-------|
-| v1.3.x or greater | v2.0.x or greater |
-| v1.2.x or lesser  | v1.0.x or greater |
+| v1.3.x or greater | v2.x.x |
+| v1.2.x or lesser  | v1.x.x |
 
 ## Configure AMDS Hardware
 

--- a/source/getting-started/user-guide/amds-interface/index.md
+++ b/source/getting-started/user-guide/amds-interface/index.md
@@ -6,6 +6,15 @@ This document describes the built-in AMDC drivers which can be used to interface
 Before attempting to use these drivers, make sure to read about the AMDS in [its documentation](/accessories/amds/index.md).
 ```
 
+## AMDS Firmware Version
+
+Ensure that your AMDS Firmware version matches your AMDC firmware version using the following table:
+
+| AMDC Version | AMDS Version |
+|-------|-------|
+| v1.3.x or greater | v2.0.x or greater |
+| v1.2.x or lesser  | v1.0.x or greater |
+
 ## Configure AMDS Hardware
 
 First, the AMDS hardware needs to be configured:


### PR DESCRIPTION
This PR:
1. fixes AMDS SPI pinout labels to close #111
2. adds documentation to indicate which version of the AMDS firmware should be used with which version of the AMDC firmware to close [AMDS issue 51](https://github.com/Severson-Group/AMDS/issues/51)