### PR TITLE
Typo in development page

### DIFF
--- a/source/firmware/development/index.md
+++ b/source/firmware/development/index.md
@@ -49,7 +49,7 @@ Refer to the diagram above for a graphical representation of how the git branchi
 The procedure for creating a new release is mostly common for all three types (major, minor, bug fix):
 
 1. Update code via topic branches which are based on `develop` and merge updates into `develop`
-2. Ensure development has stablized on the `develop` branch
+2. Ensure development has stabilized on the `develop` branch
 3. Ensure thorough testing of the latest `develop` branch code
 4. Create a final commit to `develop` where the `./CHANGELOG.md` file is updated with documentation about the new release
 


### PR DESCRIPTION
This PR fixes a spelling error in the development page of the AMDC docs.

https://github.com/Severson-Group/docs.amdc.dev/blob/c2fe46d9da1d903bd18f4045828558974f195835/source/firmware/development/index.md#L52


##
This PR closes #122