### PR TITLE
Update task profile docs

### DIFF
--- a/source/getting-started/user-guide/task-profiling.md
+++ b/source/getting-started/user-guide/task-profiling.md
@@ -80,6 +80,10 @@ void task_setup(void) {
 
 Note that `tcb` refers to the local task variable which is required for every task.
 
+```{attention}
+`task_stats_enable(&tcb.stats);` must be run after 
+```
+
 ## Viewing Timing Results
 
 After enabling task timing statistics, the system scheduler will automatically record the timing for tasks.

--- a/source/getting-started/user-guide/task-profiling.md
+++ b/source/getting-started/user-guide/task-profiling.md
@@ -81,7 +81,7 @@ void task_setup(void) {
 Note that `tcb` refers to the local task variable which is required for every task.
 
 ```{attention}
-`task_stats_enable(&tcb.stats);` must be run after 
+`task_stats_enable()` must be run after `scheduler_tcb_init()`, since the `scheduler_tcb_init()` function overrides the task stats enable status with `USER_CONFIG_ENABLE_TASK_STATISTICS_BY_DEFAULT`
 ```
 
 ## Viewing Timing Results


### PR DESCRIPTION
This PR closes #71 

An attention box message is added to inform users that the `scheduler_tcb_init()` function overrides `task_enable_stats()`.