### PR TITLE
Update sphinx-build.yml

### DIFF
--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
This updates the sphinx build on github actions to ubuntu 22.04

This closes #131 