### PR TITLE
Update GitHub workflow to use Ubuntu 24.04

### DIFF
--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Closes #131

I updated us to `24.04`, because that is the latest supported version listed [here](https://github.com/actions/runner-images). Alternatively, we could just use `ubuntu-latest`, but that seems dangerous -- we could get blindsided by an incompatibility introduced down the road.